### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/benchmark/bench-throttle.js
+++ b/benchmark/bench-throttle.js
@@ -152,6 +152,7 @@ async function benchmarkThrottle() {
       const ip = (forwarded ? forwarded.split(',')[0].trim() : null)
         || mockReq.socket.remoteAddress
         || mockReq.connection.remoteAddress;
+      void ip;
       },
     100000
   );


### PR DESCRIPTION
To fix this without changing functionality, keep the IP extraction computation exactly as-is and add a benign usage of `ip` so it is no longer unused.  
The safest minimal fix in `benchmark/bench-throttle.js` is to add `void ip;` immediately after the extraction expression in the IP extraction benchmark callback. This preserves runtime semantics (no output or logic change), keeps benchmark structure intact, and addresses CodeQL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._