### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -5,7 +5,7 @@
  * Helps users migrate between Triva versions
  */
 
-import { join, dirname } from 'path';
+import { dirname } from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
To fix this, remove only the unused named import `join` from `scripts/migrate.js` and keep `dirname`, since `dirname` is used to compute `__dirname`.

Best single fix without functional changes:
- In `scripts/migrate.js`, update the import on line 8:
  - From: `import { join, dirname } from 'path';`
  - To: `import { dirname } from 'path';`
- No other code changes are needed.
- No new methods, definitions, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._