### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/benchmark/bench-throttle.js
+++ b/benchmark/bench-throttle.js
@@ -90,7 +90,7 @@ async function benchmarkThrottle() {
       const key = `throttle:${ip}`;
 
       // Simulate rate limit check
-      const count = 1; // Under limit
+      const count = key.length % 10; // Under limit
       const allowed = count < 1000;
     },
     50000


### PR DESCRIPTION
To fix this without changing intended functionality, keep the benchmark simulation realistic by actually using the constructed throttle key in a lightweight operation (e.g., deriving `count` from it), instead of deleting it outright. This resolves the unused-variable warning while preserving the “simulate rate limit check” behavior.

Best targeted change in `benchmark/bench-throttle.js`:
- In the callback for **"Rate Limit Check (allowed)"** (around lines 88–95), replace the hardcoded `count = 1` with a value derived from `key` (still guaranteed under limit), and keep `allowed` check unchanged.
- No imports, new methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._