### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/benchmark/bench-throttle.js
+++ b/benchmark/bench-throttle.js
@@ -225,6 +225,7 @@ async function benchmarkThrottle() {
         req.headers['user-agent'],
         req.headers['accept-language']
       ].join('|');
+      return fingerprint;
     },
     50000
   );


### PR DESCRIPTION
The best fix is to make the computed `fingerprint` value observably used by returning it from the benchmark callback.  
This keeps the benchmark semantics intact (still computes fingerprint each iteration), satisfies CodeQL, and avoids introducing no-op hacks.

In `benchmark/bench-throttle.js`, within the “Request Fingerprinting” benchmark callback (around lines 223–228), keep the `const fingerprint = ...` construction and add `return fingerprint;` immediately after it. No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._