### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/benchmark/bench-middleware.js
+++ b/benchmark/bench-middleware.js
@@ -196,7 +196,7 @@ async function benchmarkMiddleware() {
     'Cookie Parser Middleware',
     async () => {
       const cookieHeader = 'session=abc123; user=john; theme=dark';
-      const cookies = cookieHeader.split(';').reduce((acc, cookie) => {
+      cookieHeader.split(';').reduce((acc, cookie) => {
         const [key, value] = cookie.trim().split('=');
         acc[key] = value;
         return acc;


### PR DESCRIPTION
Best fix: keep the cookie parsing work in place for benchmarking, but remove the unused local binding.

In `benchmark/bench-middleware.js`, inside the `'Cookie Parser Middleware'` benchmark callback (around lines 198–203), replace `const cookies = ...` with just the expression `cookieHeader.split(...).reduce(...);`. This preserves exactly the same computational workload and timing characteristics while eliminating the unused variable warning.

No imports, helper methods, or external dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._