### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/benchmark/bench-logging.js
+++ b/benchmark/bench-logging.js
@@ -84,7 +84,7 @@ async function benchmarkLogging() {
   const simpleLogResult = await runner.run(
     'Create Log Entry (simple)',
     async () => {
-      const entry = {
+      void {
         timestamp: Date.now(),
         method: 'GET',
         path: '/api/test',
@@ -100,7 +100,7 @@ async function benchmarkLogging() {
   const detailedLogResult = await runner.run(
     'Create Log Entry (detailed)',
     async () => {
-      const entry = {
+      void {
         timestamp: Date.now(),
         method: 'POST',
         path: '/api/users',


### PR DESCRIPTION
To fix unused-variable findings without changing behavior, keep the object literal evaluation but remove the unused local variable declaration.

Best fix here:
- In `benchmark/bench-logging.js`, inside benchmark callbacks where `const entry = { ... };` is used only for construction, replace with `void { ... };`.
- This preserves object creation work for the benchmark while eliminating unused bindings.
- No imports, helper methods, or dependency changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._