### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/benchmark/bench-routing.js
+++ b/benchmark/bench-routing.js
@@ -159,7 +159,6 @@ async function benchmarkRouting() {
   const multiRouteResult = await runner.run(
     'Route Matching (100 routes)',
     async () => {
-      const id = Math.floor(Math.random() * 90) + 10;
       // Simulate matching
     },
     50000


### PR DESCRIPTION
The general fix is to remove variables that are declared but not used, unless they are intentionally reserved for imminent logic (in which case a meaningful use should be added). Here, the single best fix without changing existing functionality is to delete the `id` declaration in the `'Route Matching (100 routes)'` benchmark callback, because the callback currently only simulates work and does not consume `id`.

Change needed:
- **File:** `benchmark/bench-routing.js`
- **Region:** inside `benchmarkRouting()`, in the callback passed to `runner.run` for `'Route Matching (100 routes)'` (around lines 160–164).
- **Edit:** remove `const id = Math.floor(Math.random() * 90) + 10;`.

No imports, methods, or dependency changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._