### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/benchmark/bench-throttle.js
+++ b/benchmark/bench-throttle.js
@@ -112,7 +112,7 @@ async function benchmarkThrottle() {
       ];
 
       // Count requests in window
-      const inWindow = timestamps.filter(t => t > now - windowMs).length;
+      timestamps.filter(t => t > now - windowMs).length;
     },
     50000
   );


### PR DESCRIPTION
Best fix: avoid creating an unused local and perform the computation as a standalone expression in the callback.

In `benchmark/bench-throttle.js`, inside the `Sliding Window Calculation` benchmark callback (around lines 114–116), replace:

- `const inWindow = timestamps.filter(...).length;`

with:

- `timestamps.filter(...).length;`

This keeps the same computational work for benchmarking (filter + length), avoids changing functionality/output, and removes the unused variable warning without introducing side effects or extra dependencies.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._