### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/benchmark/bench-logging.js
+++ b/benchmark/bench-logging.js
@@ -196,7 +196,7 @@ async function benchmarkLogging() {
         userAgent: 'Mozilla/5.0'
       };
 
-      const serialized = JSON.stringify(entry);
+      JSON.stringify(entry);
     },
     50000
   );


### PR DESCRIPTION
To fix this without changing functionality, remove the unnecessary variable declaration and keep the serialization call as a standalone expression.

Best single change in `benchmark/bench-logging.js`:
- In the `"Log Entry Serialization"` benchmark callback (around lines 189–200), replace:
  - `const serialized = JSON.stringify(entry);`
  with:
  - `JSON.stringify(entry);`

This preserves the benchmarked work (stringification still happens), removes the unused local variable, and satisfies CodeQL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._