### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/benchmark/bench-logging.js
+++ b/benchmark/bench-logging.js
@@ -212,7 +212,7 @@ async function benchmarkLogging() {
         statusCode: i % 2 === 0 ? 200 : 404
       }));
 
-      const filtered = logs.filter(log => log.statusCode === 404);
+      void logs.filter(log => log.statusCode === 404).length;
     },
     10000
   );


### PR DESCRIPTION
To fix the issue without changing behavior, keep the filtering operation but make the result observably used in a minimal way. The best approach here is to reference the filtered array’s `.length` and discard it with the `void` operator:

- This preserves the benchmarked computation (`filter` still runs fully).
- It avoids introducing extra output, state changes, or heavy work.
- It clearly communicates intentional discard of the result while satisfying unused-variable analysis.

Apply this in `benchmark/bench-logging.js` at the “Log Filtering” benchmark callback (around line 215): replace `const filtered = ...` with `void logs.filter(...).length;`.

No imports, helper methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._