### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/benchmark/bench-middleware.js
+++ b/benchmark/bench-middleware.js
@@ -211,7 +211,7 @@ async function benchmarkMiddleware() {
     'Body Parser (small JSON)',
     async () => {
       const body = '{"name":"test","value":123}';
-      const parsed = JSON.parse(body);
+      JSON.parse(body);
     },
     50000
   );


### PR DESCRIPTION
To fix this without changing behavior, remove the unused local variable binding and keep only the parse operation.

Best single change:
- In `benchmark/bench-middleware.js`, in the “Body Parser (small JSON)” benchmark callback (around lines 212–215), replace:
  - `const parsed = JSON.parse(body);`
  with:
  - `JSON.parse(body);`

This preserves benchmark functionality (JSON parsing still occurs each iteration) while eliminating the unused variable warning. No imports, new methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._