### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/benchmark/bench-routing.js
+++ b/benchmark/bench-routing.js
@@ -113,7 +113,7 @@ async function benchmarkRouting() {
     'Query String Parsing',
     async () => {
       const query = new URLSearchParams('?name=test&age=25&tags=js&tags=node');
-      const parsed = Object.fromEntries(query);
+      Object.fromEntries(query);
     },
     50000
   );


### PR DESCRIPTION
The best fix is to preserve the benchmarked work while removing the unused local variable assignment.

- **General approach:** if a value is intentionally computed only for side-effect-free benchmarking, do not bind it to an unused variable.
- **Best concrete fix here:** in `benchmark/bench-routing.js`, inside the “Query String Parsing” benchmark callback, replace:
  - `const parsed = Object.fromEntries(query);`
  with:
  - `Object.fromEntries(query);`
- This keeps existing functionality and benchmark behavior intact while resolving the unused-variable warning.
- No imports, helper methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._