### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/benchmark/bench-logging.js
+++ b/benchmark/bench-logging.js
@@ -229,7 +229,7 @@ async function benchmarkLogging() {
         statusCode: 200
       }));
 
-      const exported = JSON.stringify(logs, null, 2);
+      JSON.stringify(logs, null, 2);
     },
     1000
   );


### PR DESCRIPTION
To fix this, keep the benchmarked work but remove the unused local variable binding.

Best fix in this file:
- In `benchmark/bench-logging.js`, inside the `"Export Formatting"` benchmark callback, replace:
  - `const exported = JSON.stringify(logs, null, 2);`
  with:
  - `JSON.stringify(logs, null, 2);`

This preserves the exact runtime operation being benchmarked (JSON serialization) without introducing dead local state. No imports, helper methods, or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._