### PR TITLE
Fix for Useless assignment to local variable

### DIFF
--- a/benchmark/bench-throttle.js
+++ b/benchmark/bench-throttle.js
@@ -190,6 +190,7 @@ async function benchmarkThrottle() {
       } else if (context.pathname?.startsWith('/api/public')) {
         limit = 1000;
       }
+      return limit;
     },
     100000
   );


### PR DESCRIPTION
To fix this cleanly without changing intended functionality, keep the policy evaluation logic but **use the computed `limit` value**. The best minimal fix is to return `limit` from the benchmark callback in the “Policy Evaluation” section. This mirrors nearby benchmarks that already return computed values (e.g., User-Agent parsing and fingerprinting), satisfies CodeQL, and preserves benchmark intent.

Change needed in `benchmark/bench-throttle.js`:
- In the async callback passed to `runner.run` for `"Policy Evaluation"`, add `return limit;` after the `if/else if` block.
- No imports or new dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._