### PR TITLE
Fix for Useless assignment to local variable

### DIFF
--- a/benchmark/bench-throttle.js
+++ b/benchmark/bench-throttle.js
@@ -190,6 +190,7 @@ async function benchmarkThrottle() {
       } else if (context.pathname?.startsWith('/api/public')) {
         limit = 1000;
       }
+      return limit;
     },
     100000
   );


### PR DESCRIPTION
The best fix is to keep the benchmark behavior (policy evaluation with default/admin/public limits) but ensure the computed value is used. The minimal, functionality-preserving approach is to return `limit` from the async callback. This both satisfies static analysis and keeps the benchmark’s intent intact.

In `benchmark/bench-throttle.js`, within the `Policy Evaluation` benchmark callback (around lines 187–193), add a `return limit;` after the conditional block. No imports or new dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._