### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/benchmark/bench-logging.js
+++ b/benchmark/bench-logging.js
@@ -139,6 +139,7 @@ async function benchmarkLogging() {
       await Promise.resolve();
       const end = Date.now();
       const responseTime = end - start;
+      void responseTime;
     },
     50000
   );


### PR DESCRIPTION
To fix this without changing existing functionality, keep the benchmark logic the same but explicitly mark the computed value as intentionally used.

Best approach in this snippet: after computing `responseTime`, add `void responseTime;`. This is a common JS pattern to consume a value without side effects, satisfies static analysis, and preserves benchmark behavior.

Change location:
- **File:** `benchmark/bench-logging.js`
- **Region:** the callback for **"Response Time Calculation"**, around lines 137–142.
- Replace the existing block so `responseTime` is followed by `void responseTime;`.
- No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._