### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/benchmark/bench-logging.js
+++ b/benchmark/bench-logging.js
@@ -124,7 +124,7 @@ async function benchmarkLogging() {
   const timestampResult = await runner.run(
     'Timestamp Formatting',
     async () => {
-      const timestamp = new Date().toISOString();
+      void new Date().toISOString();
     },
     100000
   );


### PR DESCRIPTION
To fix this without changing functionality, replace the unused variable assignment with an explicit discard expression.  
In `benchmark/bench-logging.js`, inside the `"Timestamp Formatting"` benchmark callback (around line 127), change:

- `const timestamp = new Date().toISOString();`

to:

- `void new Date().toISOString();`

This keeps the timestamp formatting operation in the benchmark, avoids introducing side effects, and removes the unused variable.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._