### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/benchmark/bench-throttle.js
+++ b/benchmark/bench-throttle.js
@@ -134,6 +134,7 @@ async function benchmarkThrottle() {
       const burstWindow = 1000;
       const recent = timestamps.filter(t => t > Date.now() - burstWindow);
       const isBurst = recent.length > 5;
+      void isBurst;
     },
     50000
   );


### PR DESCRIPTION
To fix this without changing functionality, keep the burst computation but explicitly mark it as intentionally used/discarded, just like the existing `void ip;` pattern later in the file.

Best fix in this file/region:
- In `benchmark/bench-throttle.js`, inside the `"Burst Detection"` benchmark callback (around lines 134–137), add `void isBurst;` immediately after `const isBurst = recent.length > 5;`.
- This preserves the benchmark work, avoids changing runtime logic, and satisfies static analysis by making the variable usage explicit.
- No imports, new methods, or external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._