### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/benchmark/bench-throttle.js
+++ b/benchmark/bench-throttle.js
@@ -86,7 +86,6 @@ async function benchmarkThrottle() {
     'Rate Limit Check (allowed)',
     async () => {
       const ip = 'bench-ip-' + Math.random();
-      const timestamp = Date.now();
       const key = `throttle:${ip}`;
 
       // Simulate rate limit check


### PR DESCRIPTION
To fix an unused-variable issue safely, either (1) remove the variable if it has no behavioral purpose, or (2) integrate it into logic if it was intended to be used. Here, the best non-functional-change fix is to remove the `timestamp` declaration from the benchmark callback.

In `benchmark/bench-throttle.js`, inside `benchmarkThrottle()` in the first benchmark callback (`'Rate Limit Check (allowed)'`), delete the line:

- `const timestamp = Date.now();`

No imports, helper methods, or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._