### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/benchmark/bench-routing.js
+++ b/benchmark/bench-routing.js
@@ -102,7 +102,7 @@ async function benchmarkRouting() {
     async () => {
       const route = '/users/:id';
       const path = '/users/123';
-      const params = extractParams(route, path);
+      extractParams(route, path);
     },
     50000
   );


### PR DESCRIPTION
The best fix is to remove the unused local variable while preserving the benchmarked work.  
In `benchmark/bench-routing.js`, inside the `"Route Parameter Extraction"` benchmark callback (around lines 102–106), replace:

- `const params = extractParams(route, path);`

with:

- `extractParams(route, path);`

This keeps functionality unchanged (the extraction still runs), resolves the unused-variable warning, and avoids introducing any unrelated behavior changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._