### PR TITLE
Potential fix for code scanning alert no. 14: Log injection

### DIFF
--- a/lib/middleware/error-tracker.js
+++ b/lib/middleware/error-tracker.js
@@ -200,7 +200,9 @@ class ErrorTracker {
     if (process.env.NODE_ENV === 'development') {
       console.error(`[Error Tracker] ${entry.severity.toUpperCase()}: ${entry.error.message}`);
       if (entry.request.url) {
-        console.error(`  Request: ${entry.request.method} ${entry.request.url}`);
+        const safeMethod = String(entry.request.method ?? '').replace(/[\r\n]/g, '');
+        const safeUrl = String(entry.request.url ?? '').replace(/[\r\n]/g, '');
+        console.error(`  Request: ${safeMethod} ${safeUrl}`);
       }
       if (this.config.captureStackTrace && entry.error.stack) {
         console.error(`  Stack: ${entry.error.stack.split('\n')[1]?.trim()}`);


### PR DESCRIPTION
Potential fix for [https://github.com/TrivaJS/triva/security/code-scanning/14](https://github.com/TrivaJS/triva/security/code-scanning/14)

To fix log injection, sanitize any user-influenced values before writing them to logs by removing carriage returns and newlines (`\r`, `\n`).  
The best minimal fix here is to sanitize `entry.request.method` and `entry.request.url` at the logging point (line ~203), preserving existing behavior while neutralizing log-forging characters.

In `lib/middleware/error-tracker.js`, update the development logging block:

- Before `console.error(\`  Request: ...\`)`, create sanitized local variables:
  - Convert to string safely (fallback `''` for nullish values).
  - Strip `\r` and `\n` using `.replace(/[\r\n]/g, '')`.
- Log the sanitized values instead of raw `entry.request.method` and `entry.request.url`.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
